### PR TITLE
Add settings to support unicast cluster communication and client-only nodes.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
-elasticsearch_cluster_name: "Default Elasticsearch Cluster"
+elasticsearch_cluster_name: "{{ inventory_hostname }}-default-elasticsearch-cluster"
+elasticsearch_node_name: "{{ inventory_hostname }}-elasticsearch-node"
 # network.host setting. See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html
 elasticsearch_network_host: 0.0.0.0

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,8 @@
 ---
 elasticsearch_cluster_name: "{{ inventory_hostname }}-default-elasticsearch-cluster"
+elasticsearch_discovery_zen_ping_unicast_hosts: [ '127.0.0.1', '[::1]']
+elasticsearch_node_data: true
+elasticsearch_node_master: true
 elasticsearch_node_name: "{{ inventory_hostname }}-elasticsearch-node"
 # network.host setting. See https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html
 elasticsearch_network_host: 0.0.0.0

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -4,13 +4,13 @@
     url: 'https://packages.elastic.co/GPG-KEY-elasticsearch'
     state: present
 
-- name: Add elasticsearch 2.0 repository
+- name: Add elasticsearch 2.x repository
   apt_repository:
     repo: 'deb http://packages.elastic.co/elasticsearch/2.x/debian stable main'
     state: present
     update_cache: yes
 
-- name: Install elasticsearch 2.0
+- name: Install elasticsearch 2.x
   apt:
     package: elasticsearch
     state: present

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -2,6 +2,7 @@
 # {{ ansible_managed }}
 cluster.name: {{ elasticsearch_cluster_name }}
 network.host: {{ elasticsearch_network_host }}
+node.name: {{ elasticsearch_node_name }}
 {% if elasticsearch_path_data is defined %}
 path.data: {{ elasticsearch_path_data }}
 {% endif %}

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -1,7 +1,10 @@
 ---
 # {{ ansible_managed }}
 cluster.name: {{ elasticsearch_cluster_name }}
+discovery.zen.ping.unicast.hosts: [ {% for host in elasticsearch_discovery_zen_ping_unicast_hosts %}"{{ host }}"{% if not loop.last %},{% endif %}{% endfor %} ]
 network.host: {{ elasticsearch_network_host }}
+node.data: {{ elasticsearch_node_data | lower }}
+node.master: {{ elasticsearch_node_master | lower }}
 node.name: {{ elasticsearch_node_name }}
 {% if elasticsearch_path_data is defined %}
 path.data: {{ elasticsearch_path_data }}


### PR DESCRIPTION
Also: Change default cluster name to use inventory_hostname to prevent hosts from forming an unintentional cluster. Add node.name setting and default to inventory_hostname.

@dwcramer please review
